### PR TITLE
Instantiate trap elements lazily, instead of on require #4

### DIFF
--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -616,16 +616,10 @@ module.exports = function (el) {
 });
 $_mod.def("/makeup-keyboard-trap$0.0.4/util", function(require, exports, module, __filename, __dirname) { 'use strict';
 
-// when bundled up with isomorphic components on the server, this code is run, so we must check if
-// 'document' is defined. When it is not, on the server, we return a no-op there. Since addEventListener
-// is loaded and called in index.js on the server, we include that method as a no-op as well.
-
-var NOOP = { addEventListener: function addEventListener() {} };
 var trapBoundary = void 0;
 
 function createTrapBoundary() {
     if (trapBoundary) return trapBoundary.cloneNode();
-    if (typeof document === "undefined") return NOOP;
 
     trapBoundary = document.createElement('div');
     trapBoundary.setAttribute('tabindex', '0');
@@ -644,6 +638,8 @@ $_mod.def("/makeup-keyboard-trap$0.0.4/index", function(require, exports, module
 var focusables = require('/makeup-focusables$0.0.1/index'/*'makeup-focusables'*/);
 var util = require('/makeup-keyboard-trap$0.0.4/util'/*'./util.js'*/);
 
+// when bundled up with isomorphic components on the server, this code is run,
+// so we must check if 'document' is defined.
 var body = typeof document === "undefined" ? null : document.body;
 
 // the element that will be trapped

--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -649,12 +649,13 @@ var body = typeof document === "undefined" ? null : document.body;
 // the element that will be trapped
 var trappedEl = void 0;
 
-var topTrap = util.createTrapBoundary();
-var outerTrapBefore = util.createTrapBoundary();
-var innerTrapBefore = util.createTrapBoundary();
-var innerTrapAfter = util.createTrapBoundary();
-var outerTrapAfter = util.createTrapBoundary();
-var botTrap = util.createTrapBoundary();
+// the trap boundaries/bumpers
+var topTrap = void 0;
+var outerTrapBefore = void 0;
+var innerTrapBefore = void 0;
+var innerTrapAfter = void 0;
+var outerTrapAfter = void 0;
+var botTrap = void 0;
 
 var firstFocusableElement = void 0;
 var lastFocusableElement = void 0;
@@ -667,12 +668,21 @@ function setFocusToLastFocusableElement() {
     lastFocusableElement.focus();
 }
 
-topTrap.addEventListener('focus', setFocusToFirstFocusableElement);
-outerTrapBefore.addEventListener('focus', setFocusToFirstFocusableElement);
-innerTrapBefore.addEventListener('focus', setFocusToLastFocusableElement);
-innerTrapAfter.addEventListener('focus', setFocusToFirstFocusableElement);
-outerTrapAfter.addEventListener('focus', setFocusToLastFocusableElement);
-botTrap.addEventListener('focus', setFocusToLastFocusableElement);
+function createTraps() {
+    topTrap = util.createTrapBoundary();
+    outerTrapBefore = util.createTrapBoundary();
+    innerTrapBefore = util.createTrapBoundary();
+    innerTrapAfter = util.createTrapBoundary();
+    outerTrapAfter = util.createTrapBoundary();
+    botTrap = util.createTrapBoundary();
+
+    topTrap.addEventListener('focus', setFocusToFirstFocusableElement);
+    outerTrapBefore.addEventListener('focus', setFocusToFirstFocusableElement);
+    innerTrapBefore.addEventListener('focus', setFocusToLastFocusableElement);
+    innerTrapAfter.addEventListener('focus', setFocusToFirstFocusableElement);
+    outerTrapAfter.addEventListener('focus', setFocusToLastFocusableElement);
+    botTrap.addEventListener('focus', setFocusToLastFocusableElement);
+}
 
 function untrap() {
     if (trappedEl) {
@@ -696,7 +706,11 @@ function untrap() {
 }
 
 function trap(el) {
-    untrap();
+    if (!topTrap) {
+        createTraps();
+    } else {
+        untrap();
+    }
 
     trappedEl = el;
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 var focusables = require('makeup-focusables');
 var util = require('./util.js');
 
+// when bundled up with isomorphic components on the server, this code is run,
+// so we must check if 'document' is defined.
 var body = typeof document === "undefined" ? null : document.body;
 
 // the element that will be trapped

--- a/index.js
+++ b/index.js
@@ -8,12 +8,13 @@ var body = typeof document === "undefined" ? null : document.body;
 // the element that will be trapped
 var trappedEl = void 0;
 
-var topTrap = util.createTrapBoundary();
-var outerTrapBefore = util.createTrapBoundary();
-var innerTrapBefore = util.createTrapBoundary();
-var innerTrapAfter = util.createTrapBoundary();
-var outerTrapAfter = util.createTrapBoundary();
-var botTrap = util.createTrapBoundary();
+// the trap boundaries/bumpers
+var topTrap = void 0;
+var outerTrapBefore = void 0;
+var innerTrapBefore = void 0;
+var innerTrapAfter = void 0;
+var outerTrapAfter = void 0;
+var botTrap = void 0;
 
 var firstFocusableElement = void 0;
 var lastFocusableElement = void 0;
@@ -26,12 +27,21 @@ function setFocusToLastFocusableElement() {
     lastFocusableElement.focus();
 }
 
-topTrap.addEventListener('focus', setFocusToFirstFocusableElement);
-outerTrapBefore.addEventListener('focus', setFocusToFirstFocusableElement);
-innerTrapBefore.addEventListener('focus', setFocusToLastFocusableElement);
-innerTrapAfter.addEventListener('focus', setFocusToFirstFocusableElement);
-outerTrapAfter.addEventListener('focus', setFocusToLastFocusableElement);
-botTrap.addEventListener('focus', setFocusToLastFocusableElement);
+function createTraps() {
+    topTrap = util.createTrapBoundary();
+    outerTrapBefore = util.createTrapBoundary();
+    innerTrapBefore = util.createTrapBoundary();
+    innerTrapAfter = util.createTrapBoundary();
+    outerTrapAfter = util.createTrapBoundary();
+    botTrap = util.createTrapBoundary();
+
+    topTrap.addEventListener('focus', setFocusToFirstFocusableElement);
+    outerTrapBefore.addEventListener('focus', setFocusToFirstFocusableElement);
+    innerTrapBefore.addEventListener('focus', setFocusToLastFocusableElement);
+    innerTrapAfter.addEventListener('focus', setFocusToFirstFocusableElement);
+    outerTrapAfter.addEventListener('focus', setFocusToLastFocusableElement);
+    botTrap.addEventListener('focus', setFocusToLastFocusableElement);
+}
 
 function untrap() {
     if (trappedEl) {
@@ -55,7 +65,11 @@ function untrap() {
 }
 
 function trap(el) {
-    untrap();
+    if (!topTrap) {
+        createTraps();
+    } else {
+        untrap();
+    }
 
     trappedEl = el;
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@
 const focusables = require('makeup-focusables');
 const util = require('./util.js');
 
+// when bundled up with isomorphic components on the server, this code is run,
+// so we must check if 'document' is defined.
 const body = typeof document === "undefined" ? null : document.body;
 
 // the element that will be trapped

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,13 @@ const body = typeof document === "undefined" ? null : document.body;
 // the element that will be trapped
 let trappedEl;
 
-let topTrap = util.createTrapBoundary();
-let outerTrapBefore = util.createTrapBoundary();
-let innerTrapBefore = util.createTrapBoundary();
-let innerTrapAfter = util.createTrapBoundary();
-let outerTrapAfter = util.createTrapBoundary();
-let botTrap = util.createTrapBoundary();
+// the trap boundaries/bumpers
+let topTrap;
+let outerTrapBefore;
+let innerTrapBefore;
+let innerTrapAfter;
+let outerTrapAfter;
+let botTrap;
 
 let firstFocusableElement;
 let lastFocusableElement;
@@ -26,12 +27,21 @@ function setFocusToLastFocusableElement() {
     lastFocusableElement.focus();
 }
 
-topTrap.addEventListener('focus', setFocusToFirstFocusableElement);
-outerTrapBefore.addEventListener('focus', setFocusToFirstFocusableElement);
-innerTrapBefore.addEventListener('focus', setFocusToLastFocusableElement);
-innerTrapAfter.addEventListener('focus', setFocusToFirstFocusableElement);
-outerTrapAfter.addEventListener('focus', setFocusToLastFocusableElement);
-botTrap.addEventListener('focus', setFocusToLastFocusableElement);
+function createTraps() {
+    topTrap = util.createTrapBoundary();
+    outerTrapBefore = util.createTrapBoundary();
+    innerTrapBefore = util.createTrapBoundary();
+    innerTrapAfter = util.createTrapBoundary();
+    outerTrapAfter = util.createTrapBoundary();
+    botTrap = util.createTrapBoundary();
+
+    topTrap.addEventListener('focus', setFocusToFirstFocusableElement);
+    outerTrapBefore.addEventListener('focus', setFocusToFirstFocusableElement);
+    innerTrapBefore.addEventListener('focus', setFocusToLastFocusableElement);
+    innerTrapAfter.addEventListener('focus', setFocusToFirstFocusableElement);
+    outerTrapAfter.addEventListener('focus', setFocusToLastFocusableElement);
+    botTrap.addEventListener('focus', setFocusToLastFocusableElement);
+}
 
 function untrap() {
     if (trappedEl) {
@@ -55,7 +65,11 @@ function untrap() {
 }
 
 function trap(el) {
-    untrap();
+    if (!topTrap) {
+        createTraps();
+    } else {
+        untrap();
+    }
 
     trappedEl = el;
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,14 +1,9 @@
 'use strict';
 
-// when bundled up with isomorphic components on the server, this code is run, so we must check if
-// 'document' is defined. When it is not, on the server, we return a no-op there. Since addEventListener
-// is loaded and called in index.js on the server, we include that method as a no-op as well.
-const NOOP = { addEventListener: () => {} };
 let trapBoundary;
 
 function createTrapBoundary() {
     if (trapBoundary) return trapBoundary.cloneNode();
-    if (typeof document === "undefined") return NOOP;
 
     trapBoundary = document.createElement('div');
     trapBoundary.setAttribute('tabindex', '0');

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -56,12 +56,13 @@ var body = typeof document === "undefined" ? null : document.body;
 // the element that will be trapped
 var trappedEl = void 0;
 
-var topTrap = util.createTrapBoundary();
-var outerTrapBefore = util.createTrapBoundary();
-var innerTrapBefore = util.createTrapBoundary();
-var innerTrapAfter = util.createTrapBoundary();
-var outerTrapAfter = util.createTrapBoundary();
-var botTrap = util.createTrapBoundary();
+// the trap boundaries/bumpers
+var topTrap = void 0;
+var outerTrapBefore = void 0;
+var innerTrapBefore = void 0;
+var innerTrapAfter = void 0;
+var outerTrapAfter = void 0;
+var botTrap = void 0;
 
 var firstFocusableElement = void 0;
 var lastFocusableElement = void 0;
@@ -74,12 +75,21 @@ function setFocusToLastFocusableElement() {
     lastFocusableElement.focus();
 }
 
-topTrap.addEventListener('focus', setFocusToFirstFocusableElement);
-outerTrapBefore.addEventListener('focus', setFocusToFirstFocusableElement);
-innerTrapBefore.addEventListener('focus', setFocusToLastFocusableElement);
-innerTrapAfter.addEventListener('focus', setFocusToFirstFocusableElement);
-outerTrapAfter.addEventListener('focus', setFocusToLastFocusableElement);
-botTrap.addEventListener('focus', setFocusToLastFocusableElement);
+function createTraps() {
+    topTrap = util.createTrapBoundary();
+    outerTrapBefore = util.createTrapBoundary();
+    innerTrapBefore = util.createTrapBoundary();
+    innerTrapAfter = util.createTrapBoundary();
+    outerTrapAfter = util.createTrapBoundary();
+    botTrap = util.createTrapBoundary();
+
+    topTrap.addEventListener('focus', setFocusToFirstFocusableElement);
+    outerTrapBefore.addEventListener('focus', setFocusToFirstFocusableElement);
+    innerTrapBefore.addEventListener('focus', setFocusToLastFocusableElement);
+    innerTrapAfter.addEventListener('focus', setFocusToFirstFocusableElement);
+    outerTrapAfter.addEventListener('focus', setFocusToLastFocusableElement);
+    botTrap.addEventListener('focus', setFocusToLastFocusableElement);
+}
 
 function untrap() {
     if (trappedEl) {
@@ -103,7 +113,11 @@ function untrap() {
 }
 
 function trap(el) {
-    untrap();
+    if (!topTrap) {
+        createTraps();
+    } else {
+        untrap();
+    }
 
     trappedEl = el;
 

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -23,16 +23,10 @@ module.exports = function (el) {
 });
 $_mod.def("/makeup-keyboard-trap$0.0.4/util", function(require, exports, module, __filename, __dirname) { 'use strict';
 
-// when bundled up with isomorphic components on the server, this code is run, so we must check if
-// 'document' is defined. When it is not, on the server, we return a no-op there. Since addEventListener
-// is loaded and called in index.js on the server, we include that method as a no-op as well.
-
-var NOOP = { addEventListener: function addEventListener() {} };
 var trapBoundary = void 0;
 
 function createTrapBoundary() {
     if (trapBoundary) return trapBoundary.cloneNode();
-    if (typeof document === "undefined") return NOOP;
 
     trapBoundary = document.createElement('div');
     trapBoundary.setAttribute('tabindex', '0');
@@ -51,6 +45,8 @@ $_mod.def("/makeup-keyboard-trap$0.0.4/index", function(require, exports, module
 var focusables = require('/makeup-focusables$0.0.1/index'/*'makeup-focusables'*/);
 var util = require('/makeup-keyboard-trap$0.0.4/util'/*'./util.js'*/);
 
+// when bundled up with isomorphic components on the server, this code is run,
+// so we must check if 'document' is defined.
 var body = typeof document === "undefined" ? null : document.body;
 
 // the element that will be trapped

--- a/util.js
+++ b/util.js
@@ -1,15 +1,9 @@
 'use strict';
 
-// when bundled up with isomorphic components on the server, this code is run, so we must check if
-// 'document' is defined. When it is not, on the server, we return a no-op there. Since addEventListener
-// is loaded and called in index.js on the server, we include that method as a no-op as well.
-
-var NOOP = { addEventListener: function addEventListener() {} };
 var trapBoundary = void 0;
 
 function createTrapBoundary() {
     if (trapBoundary) return trapBoundary.cloneNode();
-    if (typeof document === "undefined") return NOOP;
 
     trapBoundary = document.createElement('div');
     trapBoundary.setAttribute('tabindex', '0');


### PR DESCRIPTION
Hi @scttdavs , now that I am instantiating the traps lazily (see diff), there is no need for the NOOP we added recently, right? Trap and untrap methods will never be called on server, right?