### PR TITLE
Add safe way to detach nodes

### DIFF
--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -726,12 +726,12 @@ function createTraps() {
 
 function untrap() {
     if (trappedEl) {
-        topTrap = body.removeChild(topTrap);
-        outerTrapBefore = trappedEl.parentNode.removeChild(outerTrapBefore);
-        innerTrapBefore = trappedEl.removeChild(innerTrapBefore);
-        innerTrapAfter = trappedEl.removeChild(innerTrapAfter);
-        outerTrapAfter = trappedEl.parentNode.removeChild(outerTrapAfter);
-        botTrap = body.removeChild(botTrap);
+        topTrap = safeDetach(topTrap);
+        outerTrapBefore = safeDetach(outerTrapBefore);
+        innerTrapBefore = safeDetach(innerTrapBefore);
+        innerTrapAfter = safeDetach(innerTrapAfter);
+        outerTrapAfter = safeDetach(outerTrapAfter);
+        botTrap = safeDetach(botTrap);
 
         trappedEl.classList.remove('keyboard-trap--active');
 
@@ -741,6 +741,12 @@ function untrap() {
         trappedEl = null;
     }
     return trappedEl;
+}
+
+function safeDetach(el) {
+    var parent = el.parentNode;
+
+    return parent ? parent.removeChild(el) : el;
 }
 
 function trap(el) {

--- a/index.js
+++ b/index.js
@@ -56,12 +56,12 @@ function createTraps() {
 
 function untrap() {
     if (trappedEl) {
-        topTrap = body.removeChild(topTrap);
-        outerTrapBefore = trappedEl.parentNode.removeChild(outerTrapBefore);
-        innerTrapBefore = trappedEl.removeChild(innerTrapBefore);
-        innerTrapAfter = trappedEl.removeChild(innerTrapAfter);
-        outerTrapAfter = trappedEl.parentNode.removeChild(outerTrapAfter);
-        botTrap = body.removeChild(botTrap);
+        topTrap = safeDetach(topTrap);
+        outerTrapBefore = safeDetach(outerTrapBefore);
+        innerTrapBefore = safeDetach(innerTrapBefore);
+        innerTrapAfter = safeDetach(innerTrapAfter);
+        outerTrapAfter = safeDetach(outerTrapAfter);
+        botTrap = safeDetach(botTrap);
 
         trappedEl.classList.remove('keyboard-trap--active');
 
@@ -71,6 +71,12 @@ function untrap() {
         trappedEl = null;
     }
     return trappedEl;
+}
+
+function safeDetach(el) {
+    var parent = el.parentNode;
+
+    return parent ? parent.removeChild(el) : el;
 }
 
 function trap(el) {

--- a/src/index.js
+++ b/src/index.js
@@ -56,12 +56,12 @@ function createTraps() {
 
 function untrap() {
     if (trappedEl) {
-        topTrap = body.removeChild(topTrap);
-        outerTrapBefore = trappedEl.parentNode.removeChild(outerTrapBefore);
-        innerTrapBefore = trappedEl.removeChild(innerTrapBefore);
-        innerTrapAfter = trappedEl.removeChild(innerTrapAfter);
-        outerTrapAfter = trappedEl.parentNode.removeChild(outerTrapAfter);
-        botTrap = body.removeChild(botTrap);
+        topTrap = safeDetach(topTrap);
+        outerTrapBefore = safeDetach(outerTrapBefore);
+        innerTrapBefore = safeDetach(innerTrapBefore);
+        innerTrapAfter = safeDetach(innerTrapAfter);
+        outerTrapAfter = safeDetach(outerTrapAfter);
+        botTrap = safeDetach(botTrap);
 
         trappedEl.classList.remove('keyboard-trap--active');
 
@@ -71,6 +71,12 @@ function untrap() {
         trappedEl = null;
     }
     return trappedEl;
+}
+
+function safeDetach(el) {
+    const parent = el.parentNode;
+
+    return parent ? parent.removeChild(el) : el;
 }
 
 function trap(el) {

--- a/test/index.js
+++ b/test/index.js
@@ -21,10 +21,10 @@ testData.forEach(function(data) {
             beforeAll(function() {
                 keyboardTrap.trap(trapEl);
             });
-            it("it should have class keyboard-trap--active on trap", function() {
+            it('it should have class keyboard-trap--active on trap', function() {
                 expect(trapEl.classList.contains('keyboard-trap--active')).toEqual(true);
             });
-            it("it should have six trap boundaries in body", function() {
+            it('it should have six trap boundaries in body', function() {
                 expect(document.querySelectorAll('.keyboard-trap-boundary').length).toEqual(6);
             });
             it('it should observe one trap event', function() {
@@ -43,10 +43,10 @@ testData.forEach(function(data) {
                 onUntrap.calls.reset();
                 keyboardTrap.untrap();
             });
-            it("it should have zero trap boundaries in body", function() {
+            it('it should have zero trap boundaries in body', function() {
                 expect(document.querySelectorAll('.keyboard-trap-boundary').length).toEqual(0);
             });
-            it("it should not have class keyboard-trap--active on trap", function() {
+            it('it should not have class keyboard-trap--active on trap', function() {
                 expect(trapEl.classList.contains('keyboard-trap--active')).toEqual(false);
             });
             it('it should observe zero trap events', function() {
@@ -54,6 +54,19 @@ testData.forEach(function(data) {
             });
             it('it should observe 1 untrap event', function() {
                 expect(onUntrap).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
+
+    describe('given trap is active, but someone messed up the DOM', function() {
+        doBeforeAll(data.html);
+        describe('when untrap method is called', function() {
+            beforeAll(function() {
+                keyboardTrap.trap(trapEl);
+                document.querySelector('.keyboard-trap-boundary').remove();
+            });
+            it('it should not blow up in our face', function() {
+                expect(keyboardTrap.untrap.bind()).not.toThrow();
             });
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -58,14 +58,14 @@ testData.forEach(function(data) {
         });
     });
 
-    describe('given trap is active, but someone messed up the DOM', function() {
+    describe('given trap is active, but the DOM has changed', function() {
         doBeforeAll(data.html);
         describe('when untrap method is called', function() {
             beforeAll(function() {
                 keyboardTrap.trap(trapEl);
                 document.querySelector('.keyboard-trap-boundary').remove();
             });
-            it('it should not blow up in our face', function() {
+            it('it should not throw an error', function() {
                 expect(keyboardTrap.untrap.bind()).not.toThrow();
             });
         });

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -132,12 +132,12 @@ function createTraps() {
 
 function untrap() {
     if (trappedEl) {
-        topTrap = body.removeChild(topTrap);
-        outerTrapBefore = trappedEl.parentNode.removeChild(outerTrapBefore);
-        innerTrapBefore = trappedEl.removeChild(innerTrapBefore);
-        innerTrapAfter = trappedEl.removeChild(innerTrapAfter);
-        outerTrapAfter = trappedEl.parentNode.removeChild(outerTrapAfter);
-        botTrap = body.removeChild(botTrap);
+        topTrap = safeDetach(topTrap);
+        outerTrapBefore = safeDetach(outerTrapBefore);
+        innerTrapBefore = safeDetach(innerTrapBefore);
+        innerTrapAfter = safeDetach(innerTrapAfter);
+        outerTrapAfter = safeDetach(outerTrapAfter);
+        botTrap = safeDetach(botTrap);
 
         trappedEl.classList.remove('keyboard-trap--active');
 
@@ -147,6 +147,12 @@ function untrap() {
         trappedEl = null;
     }
     return trappedEl;
+}
+
+function safeDetach(el) {
+    var parent = el.parentNode;
+
+    return parent ? parent.removeChild(el) : el;
 }
 
 function trap(el) {


### PR DESCRIPTION
In some situations we get an error ```NotFoundError: Node was not found``` on Firefox or ```noindex.js:60 Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.``` on Chrome.

This happens for some reason because we try to detach a node that is already detached. Making detaching safe (just check if the parentNode exists) solves the problem.